### PR TITLE
fix: replace Swashbuckle with built-in ASP.NET Core OpenAPI

### DIFF
--- a/src/Application.WebAPI/Application.WebAPI.csproj
+++ b/src/Application.WebAPI/Application.WebAPI.csproj
@@ -6,11 +6,11 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
+      <ProjectReference Include="..\Application\Application.csproj" />
     </ItemGroup>
 
     <ItemGroup>
-      <ProjectReference Include="..\Application\Application.csproj" />
+      <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="10.0.3" />
     </ItemGroup>
 
 </Project>

--- a/src/Application.WebAPI/Startup.cs
+++ b/src/Application.WebAPI/Startup.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
-using Microsoft.OpenApi.Models;
 
 namespace Ideator.API
 {
@@ -22,10 +21,7 @@ namespace Ideator.API
         {
             services.ConfigureDomainServices();
             services.AddControllers();
-            services.AddSwaggerGen(c =>
-            {
-                c.SwaggerDoc("v1", new OpenApiInfo {Title = "Application.WebAPI", Version = "v1"});
-            });
+            services.AddOpenApi();
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
@@ -34,8 +30,6 @@ namespace Ideator.API
             if (env.IsDevelopment())
             {
                 app.UseDeveloperExceptionPage();
-                app.UseSwagger();
-                app.UseSwaggerUI(c => c.SwaggerEndpoint("/swagger/v1/swagger.json", "Application.WebAPI v1"));
             }
 
             app.UseHttpsRedirection();
@@ -44,7 +38,11 @@ namespace Ideator.API
 
             app.UseAuthorization();
 
-            app.UseEndpoints(endpoints => { endpoints.MapControllers(); });
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+                endpoints.MapOpenApi();
+            });
         }
     }
 }


### PR DESCRIPTION
## Summary

- Remove `Swashbuckle.AspNetCore` which is incompatible with .NET 10
- Add `Microsoft.AspNetCore.OpenApi` (10.0.3) — the built-in OpenAPI support in ASP.NET Core 10
- Replace `AddSwaggerGen`/`UseSwagger`/`UseSwaggerUI` with `AddOpenApi`/`MapOpenApi`
- Remove unused `Microsoft.OpenApi.Models` using directive

## Test plan

- [x] `dotnet build --configuration Release` succeeds with 0 errors, 0 warnings
- [ ] CI pipeline passes
- [ ] OpenAPI document accessible at `/openapi/v1.json`